### PR TITLE
20190203c edits - dynamic table size!!

### DIFF
--- a/assets/css/test.css
+++ b/assets/css/test.css
@@ -42,12 +42,13 @@ label{
 #eventTable{
     background-color:white;
     color:black;
-    height:500px;
+    /* height:500px; */
+    margin-bottom: 0px;
 }
 #eventTable tbody{
     display:block;
-    overflow:scroll;
-    height:500px;
+    overflow-y:scroll;
+    /* height:500px; */
 }
 th{
     font-size:20px;

--- a/assets/javascript/base.js
+++ b/assets/javascript/base.js
@@ -75,6 +75,18 @@ window.onload = function () { // open onload
 //===////////////////////////////
 
 
+
+var rightSideHeightObject = $('#contentDiv').height( ($(window).height() - $('#headerDiv').height()) + "px" );
+console.log(rightSideHeightObject);
+var spotifyHeight = rightSideHeightObject[0].clientHeight - 20;
+console.log("spotifyHeight: " + spotifyHeight);
+var rightSideWidthObject = $('#rightSide').width();
+console.log(rightSideWidthObject);
+var spotifyWidth = rightSideWidthObject - 2;
+console.log("spotifyWidth: " + spotifyWidth);
+
+
+
 //============================
 // CAPTURE THE SIZE OF THE 'rightSide' DIV
 console.log("rightSide div width: " + $("#rightSide").width());

--- a/assets/javascript/base.js
+++ b/assets/javascript/base.js
@@ -82,6 +82,16 @@ console.log("rightSide div height: " + $("#rightSide").height());
 // CAPTURE THE SIZE OF THE 'leftSide' DIV
 console.log("leftSide div width: " + $("#leftSide").width());
 console.log("leftSide div height: " + $("#leftSide").height());
+// https://stackoverflow.com/questions/2435377/how-to-make-last-div-stretch-to-fill-screen
+// ^^ picked up up this div size hack from here
+$(window).resize(function(){
+    console.log("contentDiv height should be: " + ($(window).height() - $('#headerDiv').height()));
+    var tableHeightObject = $('#contentDiv').height( ($(window).height() - $('#headerDiv').height()) + "px" );
+    var tableHeight = tableHeightObject[0].clientHeight - 20;
+    console.log("resized tableHeight: " + tableHeight);
+    document.getElementById('eventTbody').setAttribute("style","height:" + tableHeight + "px; overflow-y: scroll;");
+// ^^^ add the styling for height here since we're overwriting the tbody styles in this function
+});
 //============================
 
 

--- a/assets/javascript/songkick.js
+++ b/assets/javascript/songkick.js
@@ -58,7 +58,7 @@ var songkickAPI = function() {
                 return; // exit out of the function
             };
             // if there are events, start building out the table
-            var newFirstRow = '<tbody><tr><th>Band</th><th>Venue</th><th>Date</th><th>Vote</th></tr>'; 
+            var newFirstRow = '<tbody id="eventTbody"><tr><th>Band</th><th>Venue</th><th>Date</th><th>Vote</th></tr>'; 
             $("#eventTable").append(newFirstRow); // replace first row in events table
             console.log('metro performances response came back!!!');
             console.log(response);
@@ -89,6 +89,16 @@ var songkickAPI = function() {
                 } // close FOR loop
             } // close FOR loop
             $("eventTable").append("</tbody>"); // close the tbody so the CSS height still works
+            //============================
+            // DYNAMICALLY SET THE HEIGHT OF THE EVENT TABLE
+            console.log("contentDiv height should be: " + ($(window).height() - $('#headerDiv').height()));
+            var tableHeightObject = $('#contentDiv').height( ($(window).height() - $('#headerDiv').height()) );
+            console.log("tableHeight object:");
+            console.log(tableHeightObject);
+            var tableHeight = tableHeightObject[0].clientHeight - 20;
+            console.log(tableHeight);
+            document.getElementById('eventTbody').setAttribute("style","height:" + tableHeight + "px; overflow-y: scroll;");
+            // ^^^ add the styling for height here since we're overwriting the tbody styles in this function
             console.log("artistNameArray:");
             console.log(artistNameArray);
         }).then(function() { // trigger playlist creation if we're coming back from spotify

--- a/assets/javascript/spotifyPlaylist.js
+++ b/assets/javascript/spotifyPlaylist.js
@@ -108,8 +108,17 @@ $(document).on("click", "#createPlaylistBTN", function(event) {
         console.log(response);
         });
     }).then(function() {
+        // get height/width for spotify embed
+        var rightSideHeightObject = $('#contentDiv').height( ($(window).height() - $('#headerDiv').height()) + "px" );
+        console.log(rightSideHeightObject);
+        var spotifyHeight = rightSideHeightObject[0].clientHeight - 20;
+        console.log("spotifyHeight: " + spotifyHeight);
+        var rightSideWidthObject = $('#rightSide').width();
+        console.log(rightSideWidthObject);
+        var spotifyWidth = rightSideWidthObject - 2;
+        console.log("spotifyWidth: " + spotifyWidth);
         console.log("placeholder: embed playlist on the page");
-        var playerFrame = '<iframe src="https://open.spotify.com/embed/user/' + spotifyUserID + '/playlist/' + playlistID + '" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>'
+        var playerFrame = '<iframe src="https://open.spotify.com/embed/user/' + spotifyUserID + '/playlist/' + playlistID + '" width="' + spotifyWidth + '" height="' + spotifyHeight + '" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>'
         $("#rightSide").empty();
         $("#rightSide").append(playerFrame);
         $("#pleaseWaitModal").modal("hide"); // close the modal

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
 </head>
 <body>
-    <div class="container">
+    <div class="container" id="headerDiv">
         <div class="row">
             <div class="col-md-4">
                 <h1 class="title">Band Hunt</h1>
@@ -94,11 +94,13 @@
                 <input type="text" class="form-control" value="02-16-2012">
                 <input type="text" class="form-control" value="02-16-2012">
         </div> -->
+    </div> <!-- close "all header" div -->
 
+    <div class="container" id="contentDiv">
         <div class="row">
             <div class="col-md-6" id="leftSide">
                 <table id="eventTable" class="table table-striped table-sm small">
-                    <tbody>
+                    <tbody id="eventTbody">
                     <tr>
                         <th>Band</th>
                         <th>Venue</th>
@@ -107,7 +109,7 @@
                     </tr>
                     </tbody>
                 </table>
-                <h6 class="songkick">powered by SongKick</h6>
+                <!-- <h6 class="songkick">powered by SongKick</h6> -->
             </div>
             <div class="col-md-2"></div>
             <div class="col-md-4" id="rightSide"></div>


### PR DESCRIPTION
Building on Carlar's set height on tbody to trigger proper overflows, I used JS to calculate the remaining height on the screen below all the header stuff. When the table refreshes for any reason, the tbody size updates based on the calculations. Additionally, any time a window size change is registered by JS, it updates the size of the tbody as well.

HTML changes necessary for this to work:
- all "header" type elements are now wrapped in a container with id="headerDiv"
- the event table and spotify divs are now wrapped in a container with id="contentDiv"